### PR TITLE
A better README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="frameworkArt/logo.png" alt="Framework logo" width="150" height="150"/>
+  <img src="frameworkArt/logo.png" alt="Framework logo" width="200" height="200"/>
 </div>
 
 # Blueprint

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Blueprint is a Game Framework made in [Haxe](https://haxe.org) that compiles to native platforms using hxcpp.
 Blueprint is powered by a wide range of native libraries such as [GLFW](https://www.glfw.org/),
-[OpenAL (soft)](https://openal-soft.org/), and [stb_image](https://github.com/nothings/stb).
+[OpenAL Soft](https://openal-soft.org/), and [stb_image](https://github.com/nothings/stb).
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<img src="frameworkArt/logo.png" alt="Framework logo" align="right" width="150" height="150" />
+<div align="center">
+  <img src="frameworkArt/logo.png" alt="Framework logo" width="150" height="150"/>
+</div>
 
 # Blueprint
 


### PR DESCRIPTION
I couldn't stand that streak over the logo, and it's so small, somewhere at the right, like you don't want to show it off. You shouldn't be ashamed of your logo, it perfectly should be in the middle, and of a decent, eye-catching size.

Also changed "OpenAL (soft)" text to "OpenAL Soft", because it's the correct name of the library.